### PR TITLE
Add bootstrap-sprockets to railsbricks_custom.scss so glyphicons works

### DIFF
--- a/lib/railsbricks/assets/stylesheets/railsbricks_custom.scss
+++ b/lib/railsbricks/assets/stylesheets/railsbricks_custom.scss
@@ -324,6 +324,7 @@ $hr-border: #cccccc; // Horizontal line color
 $component-offset-horizontal: 180px; // Horizontal offset for forms and lists
 
 //***********************************************************
+@import "bootstrap-sprockets";
 @import "bootstrap";
 @import "font-awesome-sprockets";
 @import "font-awesome";


### PR DESCRIPTION
glyphicons appears to fail without this line, that is suggested in bootstrap-sass docs
